### PR TITLE
Implement SPI master and slave mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MCU = atmega328p
 F_CPU = 16000000
 
 TARGET = firmware
-SRC = main.c
+SRC = $(wildcard src/*.c)
 OBJ = $(SRC:.c=.o)
 LST = $(SRC:.c=.lst)
 
@@ -61,7 +61,7 @@ all: gccversion $(TARGET).elf $(TARGET).hex size
 
 %.o : %.c
 	@echo $(MSG_COMPILING) $<
-	$(CC) $(CFLAGS) -c $< -o $(@F)
+	$(CC) $(CFLAGS) -c $< -o $(@)
 
 gccversion:
 	@$(CC) --version

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,10 @@
+//
+// Created by remco on 26-12-23.
+//
+
+#include "main.h"
+
+int main(void)
+{
+    return 0;
+}

--- a/src/main.h
+++ b/src/main.h
@@ -1,0 +1,10 @@
+//
+// Created by remco on 26-12-23.
+//
+
+#ifndef ARDUINOTEMPGRAPH_MAIN_H
+#define ARDUINOTEMPGRAPH_MAIN_H
+
+int main(void);
+
+#endif //ARDUINOTEMPGRAPH_MAIN_H

--- a/src/spi.c
+++ b/src/spi.c
@@ -1,0 +1,37 @@
+//
+// Created by remco on 5-11-23.
+//
+
+#include "spi.h"
+
+void SPI_MasterInit(void)
+{
+    // Set MOSI and SCK output, others are input by default
+    DDR_SPI = (1<<DD_MOSI) | (1<<DD_SCK);
+    // Enable SPI, Master, set clock rate fck/16
+    SPCR= (1<<SPE) | (1<<MSTR) | (1<<SPR0);
+}
+
+void SPI_MasterTransmit(char data)
+{
+    // Start transmission
+    SPDR = data;
+    // Wait for transmission to complete
+    while (!(SPSR & (1<<SPIF)));
+}
+
+void SPI_SlaveInit(void)
+{
+    // Set MISO to output, others are input by default
+    DDR_SPI = (1<<DD_MISO);
+    // Enable SPI, Master is disabled by default, clock is set by master
+    SPCR = (1<<SPE);
+}
+
+char SPI_SlaveReceive(void)
+{
+    // Wait for reception complete
+    while(!(SPSR & (1<<SPIF)));
+    // Return data register
+    return SPDR;
+}

--- a/src/spi.h
+++ b/src/spi.h
@@ -1,0 +1,14 @@
+//
+// Created by remco on 5-11-23.
+//
+
+#include <avr/io.h>
+
+#ifndef ARDUINOTEMPGRAPH_SPI_H
+#define ARDUINOTEMPGRAPH_SPI_H
+#define DDR_SPI DDRB
+#define DD_MOSI PB3
+#define DD_MISO PB4
+#define DD_SCK PB5
+
+#endif //ARDUINOTEMPGRAPH_SPI_H


### PR DESCRIPTION
Initialisation functions functions use defines for the ued pins. These defines can be set in spi.h. Default is DDRB with PB4 for MISO and PB5 for MOSI. SS is not set because regular digital IO can be used for this and it does not affect setting up SPI.