### PR TITLE
Blink LED with IO expander

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ REMOVE = rm -f
 
 MCU = atmega328p
 F_CPU = 16000000
+AVRDUDE_PORT = /dev/ttyUSB0
 
 TARGET = firmware
 SRC = $(wildcard src/*.c)
@@ -39,6 +40,7 @@ AVRDUDE_SPEED = -B 1MHz
 AVRDUDE_FLAGS = -p $(AVRDUDE_MCU)
 AVRDUDE_FLAGS += -c $(AVRDUDE_PROGRAMMER)
 AVRDUDE_FLAGS += $(AVRDUDE_SPEED)
+AVRDUDE_FLAGS += -P $(AVRDUDE_PORT)
 
 MSG_LINKING = Linking:
 MSG_COMPILING = Compiling:
@@ -74,7 +76,7 @@ analyze: $(TARGET).elf
 	$(NM) -S --size-sort -t decimal $(TARGET).elf
 
 isp: $(TARGET).hex
-	$(AVRDUDE) $(AVRDUDE_FLAGS) -U flash:w:$(TARGET).hex
+	$(AVRDUDE) $(AVRDUDE_FLAGS) -U flash:w:$(TARGET).hex:i
 
 release: isp
 

--- a/src/main.c
+++ b/src/main.c
@@ -2,9 +2,25 @@
 // Created by remco on 26-12-23.
 //
 
+#include <util/delay.h>
+
+#include "spi.h"
+#include "mcp23s17.h"
 #include "main.h"
 
 int main(void)
 {
+    SPI_MasterInit();
+    IO_Init();
+    _delay_ms(500);
+
+    while(1)
+    {
+        IO_Write(0x13, 0x01);
+        _delay_ms(1000);
+        IO_Write(0x13, 0x00);
+        _delay_ms(1000);
+    }
+
     return 0;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -5,6 +5,8 @@
 #ifndef ARDUINOTEMPGRAPH_MAIN_H
 #define ARDUINOTEMPGRAPH_MAIN_H
 
+#define F_CPU 16000000UL
+
 int main(void);
 
 #endif //ARDUINOTEMPGRAPH_MAIN_H

--- a/src/mcp23s17.c
+++ b/src/mcp23s17.c
@@ -1,0 +1,29 @@
+//
+// Created by remco on 26-12-23.
+//
+
+#include "spi.h"
+#include "mcp23s17.h"
+
+#include <util/delay.h>
+#include "spi.h"
+
+void IO_Init(void)
+{
+    // Disable sequantial writing
+    IO_Write(0x05, (1 << SEQOP));
+
+    // Set both banks to output
+    IO_Write(0x00, 0);
+    IO_Write(0x01, 0);
+}
+
+void IO_Write(uint8_t address, uint8_t data)
+{
+    SPI_ChipSelectStart();
+    uint8_t opcode = 0x40;
+    SPI_MasterTransmit(opcode);
+    SPI_MasterTransmit(address);
+    SPI_MasterTransmit(data);
+    SPI_ChipSelectStop();
+}

--- a/src/mcp23s17.h
+++ b/src/mcp23s17.h
@@ -1,0 +1,15 @@
+//
+// Created by remco on 26-12-23.
+//
+#include <avr/io.h>
+#include <stdbool.h>
+
+#ifndef ARDUINOTEMPGRAPH_MCP23S17_H
+#define ARDUINOTEMPGRAPH_MCP23S17_H
+
+#define SEQOP 5
+
+void IO_Init(void);
+void IO_Write(uint8_t address, uint8_t data);
+
+#endif //ARDUINOTEMPGRAPH_MCP23S17_H

--- a/src/spi.c
+++ b/src/spi.c
@@ -7,9 +7,10 @@
 void SPI_MasterInit(void)
 {
     // Set MOSI and SCK output, others are input by default
-    DDR_SPI = (1<<DD_MOSI) | (1<<DD_SCK);
+    DDR_SPI = (1<<DD_MOSI) | (1<<DD_SCK) | (1<<CS_PIN);
     // Enable SPI, Master, set clock rate fck/16
     SPCR= (1<<SPE) | (1<<MSTR) | (1<<SPR0);
+    CS_PORT = (1 << CS_PIN);
 }
 
 void SPI_MasterTransmit(char data)
@@ -34,4 +35,14 @@ char SPI_SlaveReceive(void)
     while(!(SPSR & (1<<SPIF)));
     // Return data register
     return SPDR;
+}
+
+void SPI_ChipSelectStart(void)
+{
+    CS_PORT = (0 << CS_PIN);
+}
+
+void SPI_ChipSelectStop(void)
+{
+    CS_PORT = (1 << CS_PIN);
 }

--- a/src/spi.h
+++ b/src/spi.h
@@ -10,5 +10,14 @@
 #define DD_MOSI PB3
 #define DD_MISO PB4
 #define DD_SCK PB5
+#define CS_PORT PORTB
+#define CS_PIN  PB2
+
+void SPI_MasterInit(void);
+void SPI_MasterTransmit(char data);
+void SPI_SlaveInit(void);
+char SPI_SlaveReceive(void);
+void SPI_ChipSelectStart(void);
+void SPI_ChipSelectStop(void);
 
 #endif //ARDUINOTEMPGRAPH_SPI_H


### PR DESCRIPTION
LED blinks on GPIOB0.
Initialising the IO expander is done by dissabling sequentiakl writes. Opcode is set to 01000001 with the last bit set 1 for write. The hardwired adress is disabled and pins should be grounded.